### PR TITLE
fix(config.ts): use optional chaining to safely access window._env_.config

### DIFF
--- a/platform/web/packages/keycloak/src/config.ts
+++ b/platform/web/packages/keycloak/src/config.ts
@@ -18,4 +18,4 @@ export interface ThemeColorsConfig {
 }
 
 // @ts-ignore
-export const config: () => Config | undefined = () => window._env_.config
+export const config: () => Config | undefined = () => window._env_?.config


### PR DESCRIPTION
The change introduces optional chaining to prevent potential runtime errors when accessing window._env_.config. This ensures that if window._env_ is undefined, the code will not throw an error, improving the robustness of the application.