### PR TITLE
chore(env): update KC_IM_CLIENT_ID in .env_dev for consistency with client naming

### DIFF
--- a/infra/docker-compose/.env_dev
+++ b/infra/docker-compose/.env_dev
@@ -18,7 +18,7 @@ KC_REALM=im-test
 KC_REALM_THEME=connect-admin-keycloakify
 KC_ADMIN_USER=admin
 KC_ADMIN_PASS=adminadmin
-KC_IM_CLIENT_ID=im-root-platform
+KC_IM_CLIENT_ID=im-root-client
 KC_IM_CLIENT_SECRET=secret
 KC_WEB_CLIENT_ID=connect-admin-web
 

--- a/infra/docker-compose/config/im-create.json
+++ b/infra/docker-compose/config/im-create.json
@@ -16,7 +16,7 @@
         "fromDisplayName": "Dev Komune",
         "replyTo": "no-reply@komune.io",
         "replyToDisplayName": "No Reploy Komune",
-        "host": "im-fake-smtp",
+        "host": "connect-admin-connect-fake-smtp",
         "port": "1025",
         "ssl": "",
         "starttls": "",


### PR DESCRIPTION
chore(im-create.json): change SMTP host to connect-admin-connect-fake-smtp for clarity The KC_IM_CLIENT_ID is updated to reflect the correct client name, ensuring consistency across the environment configuration. The SMTP host in the im-create.json file is modified to provide a clearer and more descriptive name, which helps in identifying the service being used.