### PR TITLE
fix(index.html): change favicon link type from image/svg+xml to image…

### DIFF
--- a/platform/web/packages/web-app/index.html
+++ b/platform/web/packages/web-app/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/custom.css?v=%VITE_APP_VERSION%" type="text/css" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.ico"/>
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <script src="/env-config.js?v=%VITE_APP_VERSION%"></script>
     <meta name="description" content="The accounts manager for Trace" />
     <title>Trace Connect Admin</title>


### PR DESCRIPTION
…/x-icon for better compatibility

The favicon link type is updated to image/x-icon to ensure better compatibility across different browsers, as some may not properly recognize the SVG format for favicons. This change helps maintain a consistent user experience.